### PR TITLE
Use update-copyright.py to maintain copyright blurbs

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Andy Grover <agrover@redhat.com> <andy@groveronline.com>

--- a/.update-copyright.conf
+++ b/.update-copyright.conf
@@ -5,8 +5,8 @@ vcs: Git
 [files]
 authors: yes
 files: yes
-ignored: COPYING, COPYING.LESSER, README, README.rst, MANIFEST.in,
-  .update-copyright.conf, .git*
+ignored: COPYING | COPYING.LESSER | README | README.rst | MANIFEST.in |
+  .update-copyright.conf | .git*
 
 [aliases]
 Red Hat, Inc.: Andy Grover <agrover@redhat.com>

--- a/.update-copyright.conf
+++ b/.update-copyright.conf
@@ -5,11 +5,14 @@ vcs: Git
 [files]
 authors: yes
 files: yes
-ignored: COPYING, COPYING.LESSER, README, README.rst, .update-copyright.conf,
-  .git*
+ignored: COPYING, COPYING.LESSER, README, README.rst, MANIFEST.in,
+  .update-copyright.conf, .git*
 
 [aliases]
 Red Hat, Inc.: Andy Grover <agrover@redhat.com>
+
+[author-hacks]
+kmod/kmod.pyx: Red Hat, Inc.
 
 [copyright]
 short: %(project)s comes with ABSOLUTELY NO WARRANTY and is licensed under the GNU Lesser General Public License.

--- a/.update-copyright.conf
+++ b/.update-copyright.conf
@@ -8,6 +8,9 @@ files: yes
 ignored: COPYING, COPYING.LESSER, README, README.rst, .update-copyright.conf,
   .git*
 
+[aliases]
+Red Hat, Inc.: Andy Grover <agrover@redhat.com>
+
 [copyright]
 short: %(project)s comes with ABSOLUTELY NO WARRANTY and is licensed under the GNU Lesser General Public License.
 long: This file is part of %(project)s.

--- a/.update-copyright.conf
+++ b/.update-copyright.conf
@@ -5,7 +5,8 @@ vcs: Git
 [files]
 authors: yes
 files: yes
-ignored: COPYING, COPYING.LESSER, README, .update-copyright.conf, .git*
+ignored: COPYING, COPYING.LESSER, README, README.rst, .update-copyright.conf,
+  .git*
 
 [copyright]
 short: %(project)s comes with ABSOLUTELY NO WARRANTY and is licensed under the GNU Lesser General Public License.

--- a/.update-copyright.conf
+++ b/.update-copyright.conf
@@ -1,0 +1,18 @@
+[project]
+name: python-kmod
+vcs: Git
+
+[files]
+authors: yes
+files: yes
+ignored: COPYING, COPYING.LESSER, README, .update-copyright.conf, .git*
+
+[copyright]
+short: %(project)s comes with ABSOLUTELY NO WARRANTY and is licensed under the GNU Lesser General Public License.
+long: This file is part of %(project)s.
+
+  %(project)s is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License version 2.1 as published by the Free Software Foundation.
+
+  %(project)s is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License along with %(project)s.  If not, see <http://www.gnu.org/licenses/>.

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,3 @@
+python-kmod was written by:
+Red Hat, Inc.
+W. Trevor King <wking@tremily.us>

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include AUTHORS
 include COPYING
 include COPYING.LESSER
 recursive-include kmod *.pxd

--- a/kmod/__init__.py
+++ b/kmod/__init__.py
@@ -1,15 +1,18 @@
-# Copyright (C) 2012 Red Hat, Inc. All rights reserved.
-#               2012 W. Trevor King
+# Copyright (C) 2012 W. Trevor King <wking@tremily.us>
 #
-# This copyrighted material is made available to anyone wishing to use,
-# modify, copy, or redistribute it subject to the terms and conditions
-# of the GNU Lesser General Public License v.2.1.
+# This file is part of python-kmod.
+#
+# python-kmod is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License version 2.1 as published
+# by the Free Software Foundation.
+#
+# python-kmod is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-#
-# Author: Andy Grover <agrover redhat com>
+# along with python-kmod.  If not, see <http://www.gnu.org/licenses/>.
 
 "Libkmod -- Python interface to kmod API."
 

--- a/kmod/_libkmod_h.pxd
+++ b/kmod/_libkmod_h.pxd
@@ -1,13 +1,18 @@
-# Copyright (C) 2012 Red Hat, Inc. All rights reserved.
-#               2012 W. Trevor King
+# Copyright (C) 2012 W. Trevor King <wking@tremily.us>
 #
-# This copyrighted material is made available to anyone wishing to use,
-# modify, copy, or redistribute it subject to the terms and conditions
-# of the GNU Lesser General Public License v.2.1.
+# This file is part of python-kmod.
+#
+# python-kmod is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License version 2.1 as published
+# by the Free Software Foundation.
+#
+# python-kmod is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# along with python-kmod.  If not, see <http://www.gnu.org/licenses/>.
 
 cimport libc.stdint as _stdint
 

--- a/kmod/_util.pxd
+++ b/kmod/_util.pxd
@@ -1,13 +1,18 @@
-# Copyright (C) 2012 Red Hat, Inc. All rights reserved.
-#               2012 W. Trevor King
+# Copyright (C) 2012 W. Trevor King <wking@tremily.us>
 #
-# This copyrighted material is made available to anyone wishing to use,
-# modify, copy, or redistribute it subject to the terms and conditions
-# of the GNU Lesser General Public License v.2.1.
+# This file is part of python-kmod.
+#
+# python-kmod is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License version 2.1 as published
+# by the Free Software Foundation.
+#
+# python-kmod is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# along with python-kmod.  If not, see <http://www.gnu.org/licenses/>.
 
 cimport _libkmod_h
 

--- a/kmod/_util.pyx
+++ b/kmod/_util.pyx
@@ -1,13 +1,18 @@
-# Copyright (C) 2012 Red Hat, Inc. All rights reserved.
-#               2012 W. Trevor King
+# Copyright (C) 2012 W. Trevor King <wking@tremily.us>
 #
-# This copyrighted material is made available to anyone wishing to use,
-# modify, copy, or redistribute it subject to the terms and conditions
-# of the GNU Lesser General Public License v.2.1.
+# This file is part of python-kmod.
+#
+# python-kmod is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License version 2.1 as published
+# by the Free Software Foundation.
+#
+# python-kmod is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# along with python-kmod.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys as _sys
 

--- a/kmod/error.py
+++ b/kmod/error.py
@@ -1,13 +1,18 @@
-# Copyright (C) 2012 Red Hat, Inc. All rights reserved.
-#               2012 W. Trevor King
+# Copyright (C) 2012 W. Trevor King <wking@tremily.us>
 #
-# This copyrighted material is made available to anyone wishing to use,
-# modify, copy, or redistribute it subject to the terms and conditions
-# of the GNU Lesser General Public License v.2.1.
+# This file is part of python-kmod.
+#
+# python-kmod is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License version 2.1 as published
+# by the Free Software Foundation.
+#
+# python-kmod is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# along with python-kmod.  If not, see <http://www.gnu.org/licenses/>.
 
 class KmodError (Exception):
     pass

--- a/kmod/kmod.pxd
+++ b/kmod/kmod.pxd
@@ -1,13 +1,18 @@
-# Copyright (C) 2012 Red Hat, Inc. All rights reserved.
-#               2012 W. Trevor King
+# Copyright (C) 2012 W. Trevor King <wking@tremily.us>
 #
-# This copyrighted material is made available to anyone wishing to use,
-# modify, copy, or redistribute it subject to the terms and conditions
-# of the GNU Lesser General Public License v.2.1.
+# This file is part of python-kmod.
+#
+# python-kmod is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License version 2.1 as published
+# by the Free Software Foundation.
+#
+# python-kmod is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# along with python-kmod.  If not, see <http://www.gnu.org/licenses/>.
 
 cimport _libkmod_h
 

--- a/kmod/kmod.pyx
+++ b/kmod/kmod.pyx
@@ -1,13 +1,19 @@
-# Copyright (C) 2012 Red Hat, Inc. All rights reserved.
-#               2012 W. Trevor King
+# Copyright (C) 2012 Red Hat, Inc.
+#                    W. Trevor King <wking@tremily.us>
 #
-# This copyrighted material is made available to anyone wishing to use,
-# modify, copy, or redistribute it subject to the terms and conditions
-# of the GNU Lesser General Public License v.2.1.
+# This file is part of python-kmod.
+#
+# python-kmod is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License version 2.1 as published
+# by the Free Software Foundation.
+#
+# python-kmod is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# along with python-kmod.  If not, see <http://www.gnu.org/licenses/>.
 
 "Define the Kmod class"
 

--- a/kmod/list.pxd
+++ b/kmod/list.pxd
@@ -1,13 +1,18 @@
-# Copyright (C) 2012 Red Hat, Inc. All rights reserved.
-#               2012 W. Trevor King
+# Copyright (C) 2012 W. Trevor King <wking@tremily.us>
 #
-# This copyrighted material is made available to anyone wishing to use,
-# modify, copy, or redistribute it subject to the terms and conditions
-# of the GNU Lesser General Public License v.2.1.
+# This file is part of python-kmod.
+#
+# python-kmod is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License version 2.1 as published
+# by the Free Software Foundation.
+#
+# python-kmod is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# along with python-kmod.  If not, see <http://www.gnu.org/licenses/>.
 
 cimport _libkmod_h
 

--- a/kmod/list.pyx
+++ b/kmod/list.pyx
@@ -1,13 +1,18 @@
-# Copyright (C) 2012 Red Hat, Inc. All rights reserved.
-#               2012 W. Trevor King
+# Copyright (C) 2012 W. Trevor King <wking@tremily.us>
 #
-# This copyrighted material is made available to anyone wishing to use,
-# modify, copy, or redistribute it subject to the terms and conditions
-# of the GNU Lesser General Public License v.2.1.
+# This file is part of python-kmod.
+#
+# python-kmod is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License version 2.1 as published
+# by the Free Software Foundation.
+#
+# python-kmod is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# along with python-kmod.  If not, see <http://www.gnu.org/licenses/>.
 
 cimport _libkmod_h
 

--- a/kmod/module.pxd
+++ b/kmod/module.pxd
@@ -1,13 +1,18 @@
-# Copyright (C) 2012 Red Hat, Inc. All rights reserved.
-#               2012 W. Trevor King
+# Copyright (C) 2012 W. Trevor King <wking@tremily.us>
 #
-# This copyrighted material is made available to anyone wishing to use,
-# modify, copy, or redistribute it subject to the terms and conditions
-# of the GNU Lesser General Public License v.2.1.
+# This file is part of python-kmod.
+#
+# python-kmod is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License version 2.1 as published
+# by the Free Software Foundation.
+#
+# python-kmod is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# along with python-kmod.  If not, see <http://www.gnu.org/licenses/>.
 
 cimport _libkmod_h
 cimport list as _list

--- a/kmod/module.pyx
+++ b/kmod/module.pyx
@@ -1,13 +1,18 @@
-# Copyright (C) 2012 Red Hat, Inc. All rights reserved.
-#               2012 W. Trevor King
+# Copyright (C) 2012 W. Trevor King <wking@tremily.us>
 #
-# This copyrighted material is made available to anyone wishing to use,
-# modify, copy, or redistribute it subject to the terms and conditions
-# of the GNU Lesser General Public License v.2.1.
+# This file is part of python-kmod.
+#
+# python-kmod is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License version 2.1 as published
+# by the Free Software Foundation.
+#
+# python-kmod is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# along with python-kmod.  If not, see <http://www.gnu.org/licenses/>.
 
 import collections as _collections
 

--- a/kmod/version.py
+++ b/kmod/version.py
@@ -1,12 +1,17 @@
-# Copyright (C) 2012 Red Hat, Inc. All rights reserved.
-#               2012 W. Trevor King
+# Copyright (C) 2012 W. Trevor King <wking@tremily.us>
 #
-# This copyrighted material is made available to anyone wishing to use,
-# modify, copy, or redistribute it subject to the terms and conditions
-# of the GNU Lesser General Public License v.2.1.
+# This file is part of python-kmod.
+#
+# python-kmod is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License version 2.1 as published
+# by the Free Software Foundation.
+#
+# python-kmod is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# along with python-kmod.  If not, see <http://www.gnu.org/licenses/>.
 
 __version__ = '0.1'

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,19 @@
-# Copyright (C) 2012 Red Hat, Inc. All rights reserved.
-#               2012 W. Trevor King
+# Copyright (C) 2012 Red Hat, Inc.
+#                    W. Trevor King <wking@tremily.us>
 #
-# This copyrighted material is made available to anyone wishing to use,
-# modify, copy, or redistribute it subject to the terms and conditions
-# of the GNU Lesser General Public License v.2.1.
+# This file is part of python-kmod.
+#
+# python-kmod is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License version 2.1 as published
+# by the Free Software Foundation.
+#
+# python-kmod is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# along with python-kmod.  If not, see <http://www.gnu.org/licenses/>.
 
 from distutils.core import setup
 from distutils.extension import Extension as _Extension


### PR DESCRIPTION
Use Git to track authors, so you don't have to.

As requested in https://github.com/agrover/python-kmod/pull/3#issuecomment-9674884
